### PR TITLE
Minor corrections to YAML and TOML cheatsheets

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -197,7 +197,7 @@ text = "Great Article!"
 author = "Anonymous"
 text = "Love it!"
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json
 {
 	"comments" : [
@@ -219,7 +219,7 @@ text = "Love it!"
 [dog."tater.man"]
 type = "pug"
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json
 {
   "dog": {
@@ -238,7 +238,7 @@ type = "pug"
 [foo.bar.baz]
 bat = "hi"
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json
 {
 	"foo" : {

--- a/toml.md
+++ b/toml.md
@@ -18,7 +18,7 @@ Getting started {.cols-3}
 
 ### Introduction
 [TOML](https://toml.io/en/) is a minimal configuration file format that's easy to read due to obvious semantics. 
-- [Document](https://toml.io/en/latest) _(yaml.org)_
+- [Document](https://toml.io/en/latest) _(toml.io)_
 - [Learn X in Y minutes](https://learnxinyminutes.com/docs/toml/) _(learnxinyminutes.com)_
 
 

--- a/yaml.md
+++ b/yaml.md
@@ -42,7 +42,7 @@ b: false         # boolean type
 
 d: 2015-04-05    # date type
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "n1": 1,
@@ -62,7 +62,7 @@ Use spaces to indent. There must be space between the element parts.
 some_thing: &VAR_NAME foobar
 other_thing: *VAR_NAME
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "some_thing": "foobar",
@@ -91,7 +91,7 @@ description: |
   hello
   world
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {"description": "hello\nworld\n"}
 ```
@@ -108,7 +108,7 @@ child:
   <<: *defaults
   b: 4
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "parent": {
@@ -133,7 +133,7 @@ values: &ref
 other_values:
   i_am_ref: *ref
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "values": [
@@ -156,7 +156,7 @@ description: >
   hello
   world
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {"description": "hello world\n"}
 ```
@@ -186,7 +186,7 @@ YAML Collections {.cols-3}
 - Sammy Sosa
 - Ken Griffey
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 [
   "Mark McGwire",
@@ -202,7 +202,7 @@ hr:  65       # Home runs
 avg: 0.278    # Batting average
 rbi: 147      # Runs Batted In
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "hr": 65,
@@ -220,7 +220,7 @@ attributes:
   - a2
 methods: [getter, setter]
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "attributes": ["a1", "a2"],
@@ -243,7 +243,7 @@ children:
     name: Sammy Sosa
     age: 12
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "children": [
@@ -266,7 +266,7 @@ my_sequences:
     - 9
     - 0 
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "my_sequences": [
@@ -286,7 +286,7 @@ Sammy Sosa: {
     avg: 0.288
   }
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "Mark McGwire": {
@@ -313,7 +313,7 @@ Jack:
     - b
   location: {country: "A", city: "A-A"}
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "Jack": {
@@ -336,7 +336,7 @@ set1: !!set
   ? two
 set2: !!set {'one', "two"}
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "set1": {"one": null, "two": null},
@@ -353,7 +353,7 @@ ordered: !!omap
 - Sammy Sosa: 63
 - Ken Griffy: 58
 ```
-#### ↓ Equavalent JSON
+#### ↓ Equivalent JSON
 ```json {.wrap}
 {
   "ordered": [


### PR DESCRIPTION
Two minor corrections - 

- Domain of link to toml.io
- Spelling of 'equivalent'