### PR TITLE
Fix: remove `[]` of the array in concat method

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -574,7 +574,7 @@ const newFirstElement = 4
 [newFirstElement].concat(array)
     
 // => [ 3, 2, 1, 4 ]
-[array].concat(newFirstElement)
+array.concat(newFirstElement)
 ```
 if you want to avoid mutating your original array, you can use concat.
 


### PR DESCRIPTION
This fixes the difference between commented results and the actual code results in the `Method.concat() example` :
```
.
.
// => [ 3, 2, 1, 4 ]
[array].concat(newFirstElement) // it actually returns => [ [ 3, 2, 1 ], 4 ]
```